### PR TITLE
feat: add @jameslnewell/vitest-config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,8 @@
       "@jameslnewell/editor-config",
       "@jameslnewell/prettier-config",
       "@jameslnewell/eslint-config",
-      "@jameslnewell/typescript-config"
+      "@jameslnewell/typescript-config",
+      "@jameslnewell/vitest-config"
     ]
   ],
   "linked": [],

--- a/.changeset/vitest-config.md
+++ b/.changeset/vitest-config.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/vitest-config': minor
+---
+
+New package: shared Vitest configuration mirroring the `@jameslnewell/jest-preset` conventions (Node environment, `src/**` + `test/**` test globs, `v8` coverage). Consume via Vitest's `mergeConfig`.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,6 +2,10 @@
   "name": "@jameslnewell/eslint-config",
   "version": "1.0.0",
   "main": "index.mjs",
+  "exports": {
+    ".": "./index.mjs",
+    "./node": "./node.mjs"
+  },
   "files": [
     "index.mjs",
     "node.mjs"

--- a/packages/vitest-config/README.md
+++ b/packages/vitest-config/README.md
@@ -1,0 +1,46 @@
+# @jameslnewell/vitest-config
+
+Shared [Vitest](https://vitest.dev) configuration.
+
+Mirrors the `@jameslnewell/jest-preset` conventions: a Node environment and
+`src/**` + `test/**` test globs, with `v8` coverage.
+
+## Install
+
+```sh
+pnpm add -D @jameslnewell/vitest-config vitest
+```
+
+## Usage
+
+Vitest has no "preset" mechanism, so merge the shared config with your own
+overrides using `mergeConfig`:
+
+```ts
+// vitest.config.ts
+import {defineConfig, mergeConfig} from 'vitest/config';
+import shared from '@jameslnewell/vitest-config';
+
+export default mergeConfig(
+  shared,
+  defineConfig({
+    // per-project overrides
+  }),
+);
+```
+
+Or use it as-is:
+
+```ts
+// vitest.config.ts
+export {default} from '@jameslnewell/vitest-config';
+```
+
+## Coverage
+
+Coverage uses the `v8` provider. If you run `vitest --coverage`, also install
+the provider:
+
+```sh
+pnpm add -D @vitest/coverage-v8
+```

--- a/packages/vitest-config/eslint.config.mjs
+++ b/packages/vitest-config/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from '@jameslnewell/eslint-config/node';
+
+export default config;

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@jameslnewell/vitest-config",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jameslnewell/configs.git",
+    "directory": "packages/vitest-config"
+  },
+  "main": "vitest-config.mjs",
+  "files": [
+    "vitest-config.mjs"
+  ],
+  "peerDependencies": {
+    "vitest": "^4.0.0"
+  },
+  "devDependencies": {
+    "@jameslnewell/eslint-config": "workspace:*",
+    "@jameslnewell/prettier-config": "workspace:*",
+    "@types/node": "^25.3.0",
+    "eslint": "^10.6.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "prettier": "@jameslnewell/prettier-config",
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "typing:check": "tsc --noEmit",
+    "linting:check": "eslint .",
+    "linting:fix": "eslint --fix .",
+    "formatting:check": "prettier --check .",
+    "formatting:fix": "prettier --write ."
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/vitest-config/tsconfig.json
+++ b/packages/vitest-config/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["*.mjs", "*.js", "*.ts"]
+}

--- a/packages/vitest-config/vitest-config.mjs
+++ b/packages/vitest-config/vitest-config.mjs
@@ -1,0 +1,31 @@
+import {defineConfig} from 'vitest/config';
+
+/**
+ * Shared Vitest configuration.
+ *
+ * Mirrors the `@jameslnewell/jest-preset` conventions: a Node environment and
+ * `src/**` + `test/**` test globs. Consumers merge it with their own overrides
+ * using Vitest's `mergeConfig`:
+ *
+ * ```ts
+ * import {defineConfig, mergeConfig} from 'vitest/config';
+ * import shared from '@jameslnewell/vitest-config';
+ *
+ * export default mergeConfig(shared, defineConfig({}));
+ * ```
+ *
+ * Coverage uses the `v8` provider; install `@vitest/coverage-v8` if you run
+ * `vitest --coverage`.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,27 @@ importers:
         specifier: workspace:*
         version: link:../prettier-config
 
+  packages/vitest-config:
+    devDependencies:
+      '@jameslnewell/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@jameslnewell/prettier-config':
+        specifier: workspace:*
+        version: link:../prettier-config
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.5.0
+      eslint:
+        specifier: ^10.6.0
+        version: 10.6.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.5.0)(vite@8.1.3(@types/node@25.5.0))
+
 packages:
   '@babel/code-frame@7.27.1':
     resolution:
@@ -4187,13 +4208,6 @@ packages:
       }
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution:
-      {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
-      }
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution:
       {
@@ -5554,7 +5568,7 @@ snapshots:
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -5568,14 +5582,14 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.3.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@25.3.0)(ts-node@10.9.2(@swc/core@1.15.7)(@types/node@25.3.0)(typescript@6.0.3))
+      jest-config: 30.2.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.7)(@types/node@25.3.0)(typescript@6.0.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -5606,7 +5620,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       jest-mock: 30.2.0
 
   '@jest/expect-utils@29.7.0':
@@ -5628,7 +5642,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.2.0
       '@sinonjs/fake-timers': 13.0.5
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       jest-message-util: 30.2.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
@@ -5646,7 +5660,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.2.0':
@@ -5657,7 +5671,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -5737,7 +5751,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -5747,7 +5761,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6030,7 +6044,6 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
-    optional: true
 
   '@types/stack-utils@2.0.3': {}
 
@@ -6109,7 +6122,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6220,6 +6233,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.3(@types/node@25.3.0)
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@25.5.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@25.5.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -6946,10 +6967,6 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -7376,7 +7393,7 @@ snapshots:
       '@jest/expect': 30.2.0
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.1
@@ -7448,6 +7465,39 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.2.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.7)(@types/node@25.3.0)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.2.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.5.0
+      ts-node: 10.9.2(@swc/core@1.15.7)(@types/node@25.3.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -7479,7 +7529,7 @@ snapshots:
       '@jest/environment': 30.2.0
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
@@ -7489,7 +7539,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7547,7 +7597,7 @@ snapshots:
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       jest-util: 30.2.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
@@ -7581,7 +7631,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -7610,7 +7660,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       cjs-module-lexer: 2.1.1
       collect-v8-coverage: 1.0.3
@@ -7657,7 +7707,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -7666,11 +7716,11 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.5
 
   jest-validate@30.2.0:
     dependencies:
@@ -7685,7 +7735,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -7694,7 +7744,7 @@ snapshots:
 
   jest-worker@30.2.0:
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.2.0
       merge-stream: 2.0.0
@@ -8015,8 +8065,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.5: {}
 
@@ -8355,8 +8403,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
@@ -8531,6 +8579,17 @@ snapshots:
       '@types/node': 25.3.0
       fsevents: 2.3.3
 
+  vite@8.1.3(@types/node@25.5.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.5.0
+      fsevents: 2.3.3
+
   vitest@4.1.10(@types/node@25.3.0)(vite@8.1.3(@types/node@25.3.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -8545,16 +8604,43 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.3(@types/node@25.3.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@25.5.0)(vite@8.1.3(@types/node@25.5.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.5.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@25.5.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## What

New shared **Vitest** config package, `@jameslnewell/vitest-config`, mirroring `@jameslnewell/jest-preset`:

- Node environment, `src/**/*.test.ts` + `test/**/*.test.ts` globs, `v8` coverage.
- Static `.mjs` (no build), same shape/conventions as the other config packages.
- Consumed via Vitest's `mergeConfig` (Vitest has no "preset" mechanism) — documented in the README.
- Joined the lock-step `fixed` group so it versions with the rest.

## Also

Adds an `exports` map to `@jameslnewell/eslint-config` so the `@jameslnewell/eslint-config/node` subpath resolves under NodeNext/ESM (a bare subpath without `exports` doesn't auto-resolve to `.mjs`). vitest-config is the first consumer of that subpath; the scaffolds in PR 5 will be too.

## Verification

Full repo green: `pnpm -r run typing:check`, `linting:check`, `formatting:check`, `test`.

Depends on **PR 2** — based on that branch.

## Delivery — PR 3 of 5
1. Lock-step config versioning
2. eslint-config major (Jest→Vitest) + latest tooling
3. **`@jameslnewell/vitest-config`** ← this PR
4. `@jameslnewell/tsup-config`
5. `@jameslnewell/create-package`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KuwxoPED8jSUH4zM77Tys