### PR TITLE
chore: modernize base tsconfig, drop per-package overrides

### DIFF
--- a/.changeset/typescript-config-modernize.md
+++ b/.changeset/typescript-config-modernize.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/typescript-config': major
+---
+
+Modernise the base config: `module`/`moduleResolution` → `NodeNext`, add `target: "ESNext"`, and drop the deprecated `importsNotUsedAsValues`. Consuming packages no longer need to override these per-package.

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "target": "ESNext",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/packages/jest-preset/tsconfig.json
+++ b/packages/jest-preset/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "target": "ESNext",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/packages/prettier-config/tsconfig.json
+++ b/packages/prettier-config/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "target": "ESNext",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -20,15 +20,15 @@
     "strictPropertyInitialization": true,
     "useUnknownInCatchVariables": true,
 
-    "importsNotUsedAsValues": "remove",
     "sourceMap": true,
 
     "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-
-    "moduleResolution": "node"
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
## What

Modernizes the shared `@jameslnewell/typescript-config` base so packages stop repeating the same module/target settings.

**Base (`packages/typescript-config/tsconfig.json`):**
- `moduleResolution: "node"` (node10, deprecated under TS 6 — `TS5107`) → **`"NodeNext"`**
- add **`module: "NodeNext"`** and **`target: "ESNext"`**
- drop the deprecated **`importsNotUsedAsValues: "remove"`**

**Consuming packages** (`eslint-config`, `prettier-config`, `jest-preset`) drop the now-redundant `module` / `moduleResolution` / `target` overrides — they inherit them from the base and keep only their package-specific `allowJs` / `checkJs` / `noEmit` / `types` / `include`.

## Why

Every node config package was repeating the identical `module: NodeNext` / `moduleResolution: NodeNext` / `target: ESNext` trio purely to override a dated base. Hoisting them into the base removes the duplication and drops two deprecated options.

`eslint-config-react` keeps its own explicit `CommonJS`/`node` settings (it's legacy and slated for removal).

## Verification

Green on `master`'s tooling (ESLint 9 / TS 5.9) and validated on TS 6: `typing:check`, `linting:check`, `formatting:check`, `test`.

## Note

`@jameslnewell/typescript-config` is in the lock-step `fixed` group, so this breaking base change ships with the coordinated major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KuwxoPED8jSUH4zM77Tys